### PR TITLE
feat: Update hero section button and add icons

### DIFF
--- a/components/landing/hero.tsx
+++ b/components/landing/hero.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/navigation";
 import { Button } from "../ui/button";
 import Image from "next/image";
+import { Landmark, Receipt } from "lucide-react";
 
 export function Hero() {
 
@@ -15,9 +16,14 @@ export function Hero() {
             <div className="max-w-2xl max-sm:w-60 text-center">
                 <p className="text-base max-md:text-sm max-sm:text-xs">Giving 3-Wheeler drivers the keys to ownership, and investors access to fractionalized opportunities to earn steady returns.</p>
             </div>
-            <div className="flex gap-6 max-md:flex-col">
-                <Button className="rounded-full px-12 py-7 max-sm:px-8 max-sm:py-6" onClick={() => router.push("https://member.3wb.club")}>Drive a 3-Wheeler</Button>
-                <Button className="rounded-full px-12 py-7 max-sm:px-8 max-sm:py-6 border-yellow-500" variant="outline" onClick={() => router.push("https://finance.3wb.club")}>Finance a 3-Wheeler</Button>
+            <div className="flex gap-6 flex-col">
+                <Button className="rounded-full px-12 py-7 max-sm:px-8 max-sm:py-6 border-grey-500" variant="default" onClick={() => router.push("https://finance.3wb.club")}>
+                    <div className="flex">
+                        <Receipt />
+                        <Landmark />
+                    </div>
+                    Finance a 3-Wheeler
+                </Button>
             </div>
             <div className="absolute inset-0 flex justify-center items-center z-[-1] opacity-50 max-sm:mt-60">
                 <Image className="max-2xl:w-5/6 max-2xl:h-5/6" src="/images/kekeHero.svg" alt="Keke Hero" width={800} height={800} />


### PR DESCRIPTION
Replaces the two previous buttons with a single 'Finance a 3-Wheeler' button in the hero section, adds Landmark and Receipt icons from lucide-react, and adjusts button styling and layout for improved visual presentation.